### PR TITLE
Fix: Add dynamic resolution scaling to crop_video.py to support various video resolutions

### DIFF
--- a/utils/crop_video.py
+++ b/utils/crop_video.py
@@ -159,9 +159,24 @@ def crop_all_utts(args, frames_dir, utt_dir):
 
         if audio_start < 0:
             raise ValueError("The audio start frame cannot be negative.")
+        
+        # scale resolution, face coordinates per frame, width & height data
+        sample_img = cv2.imread(flist[0])
+        actual_h, actual_w = sample_img.shape[:2]
+        
+        sw = actual_w / image_size_x
+        sh = actual_h / image_size_y
 
-        # face coordinates per frame, width & height data
-        frame_list = [data.split(" ") for data in lines[lineno:]]
+        frame_list = []
+        for data in lines[lineno:]:
+            parts = data.strip().split()
+            if len(parts) >= 5:
+                idx = parts[0]
+                x = str(int(float(parts[1]) * sw))
+                y = str(int(float(parts[2]) * sh))
+                w = str(int(float(parts[3]) * sw))
+                h = str(int(float(parts[4]) * sh))
+                frame_list.append([idx, x, y, w, h] + parts[5:])
 
         # adjust frame length according to audio start and end info
         crop_regions = adjust_av_index(audio_start_frame, audio_end_frame, frame_list)


### PR DESCRIPTION
## Description
This PR addresses an issue in `utils/crop_video.py` where the facial cropping region becomes incorrect if the downloaded video's resolution does not exactly match the base resolution (e.g., 1280x720) specified in the ASD info file.

## Why is this necessary?
The original implementation assumes that the input video has the exact same dimensions as the `# ImageSize` defined in the annotation texts. However, videos downloaded from YouTube (via `yt-dlp` or similar tools) often come in 1080p or other arbitrary resolutions. When a 1080p video is processed using 720p coordinates without scaling, it results in cropping the wrong background region instead of the speaker's mouth.

## Changes Made
- Added a dynamic scaling logic that compares the actual resolution of the input video frame with the `# ImageSize` from the ASD info file.
- Calculated the scale factors (`sw`, `sh`) and multiplied them by the original X, Y, W, H coordinates to correctly adjust the bounding box regardless of the video's original resolution.

## How to Test
1. Download a 1080p or 4K video from the dataset list.
2. Run the modified `crop_video.py`.
3. Verify that the output `.mp4` files in the `utts/` directory successfully contain the cropped lip/face regions.